### PR TITLE
Fix bugs in both Dockerfile's

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       - "4505"
       - "4506"
     volumes:
-      - ./saltmaster/srv:/srv
+      - ./saltmaster/srv/pillar:/srv/pillar
+      - ./saltmaster/srv/salt:/srv/salt
 
   minion01:
     build: saltminion

--- a/saltmaster/Dockerfile
+++ b/saltmaster/Dockerfile
@@ -4,27 +4,23 @@ LABEL maintainer="info@warpnet.nl"
 # Set shell option -o before running shell commands with pipes in them
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Configure TZdata
-RUN ln -sf /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    sudo \
+    gpg-agent \
+    dirmngr \
+  && rm -rf /var/lib/apt/lists/*
 
-# Installation of the latest salt
-RUN sed -i 's/archive.ubuntu/nl.archive.ubuntu/' /etc/apt/sources.list
-# hadolint ignore=DL3009
-RUN apt-get update
-# hadolint ignore=DL3009
-RUN apt-get install -y --no-install-recommends wget curl software-properties-common vim sudo net-tools iputils-ping netcat
-RUN wget -O - https://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
+# Add SaltStack repository
+RUN apt-key adv --fetch-keys https://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub
 RUN echo 'deb http://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest bionic main' > /etc/apt/sources.list.d/saltstack.list
-# hadolint ignore=DL3009
-RUN apt-get update
 
 # Install the salt master
-RUN apt-get install -y --no-install-recommends salt-master \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-# Mount /srv/salt and /srv/pillar
-VOLUME ["/srv/salt","/srv/pillar"]
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    salt-master \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add run file
 COPY run_saltmaster.sh /usr/local/bin/run_saltmaster.sh

--- a/saltminion/Dockerfile
+++ b/saltminion/Dockerfile
@@ -4,24 +4,23 @@ LABEL maintainer="info@warpnet.nl"
 # Set shell option -o before running shell commands with pipes in them
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Configure TZdata
-RUN ln -sf /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    sudo \
+    gpg-agent \
+    dirmngr \
+  && rm -rf /var/lib/apt/lists/*
 
-# Installation of the latest salt
-RUN sed -i 's/archive.ubuntu/nl.archive.ubuntu/' /etc/apt/sources.list
-# hadolint ignore=DL3009
-RUN apt-get update
-# hadolint ignore=DL3009
-RUN apt-get install -y --no-install-recommends wget curl software-properties-common vim sudo net-tools iputils-ping netcat \
-RUN wget -O - https://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
+# Add SaltStack repository
+RUN apt-key adv --fetch-keys https://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest/SALTSTACK-GPG-KEY.pub
 RUN echo 'deb http://repo.saltstack.com/py3/ubuntu/18.04/amd64/latest bionic main' > /etc/apt/sources.list.d/saltstack.list
-# hadolint ignore=DL3009
-RUN apt-get update
 
-# Install the salt master
-RUN apt-get install -y --no-install-recommends salt-minion \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+# Install the salt minion
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    salt-minion \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add run file
 COPY run_saltminion.sh /usr/local/bin/run_saltminion.sh


### PR DESCRIPTION
Fix bugs in both Dockerfile's:
- Update retrieval of the GPG key for the SaltStack repository.
- Add missing packages.
- Remove optional packages e.g. vim.
- Inline the `apt-get update` commands.
- Separate the salt and pillar volumes.