### PR TITLE
Update build badge to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Travis (.org)](https://img.shields.io/travis/warpnet/docker-saltstack/master.svg?style=for-the-badge)](https://travis-ci.org/warpnet/docker-saltstack)
+[![Travis (.org)](https://img.shields.io/travis/warpnet/docker-saltstack/main.svg?style=for-the-badge)](https://travis-ci.org/warpnet/docker-saltstack)
 
 # Readme
 


### PR DESCRIPTION
Update build badge to use the `main` branch instead of `master`.